### PR TITLE
Remove time.Sleep from the tablescanner iter()

### DIFF
--- a/sds/client/tablescanner.go
+++ b/sds/client/tablescanner.go
@@ -5,6 +5,8 @@ import (
 	"github.com/XiaoMi/galaxy-sdk-go/sds/errors"
 	"github.com/XiaoMi/galaxy-sdk-go/sds/table"
 	"github.com/golang/glog"
+  	"runtime"
+
 )
 
 type TableScanner struct {
@@ -64,6 +66,6 @@ func (p *TableScanner) Iter() <-chan *ScannedItem {
 		}
 		close(ch)
 	}()
-	time.Sleep(time.Second)
+  	runtime.Gosched()
 	return ch
 }


### PR DESCRIPTION
背景：用户在使用SDS-GO-SDK时发现在使用scanner过程中每次调用Iter时延迟较大，查看源码后发现每次Iter结束后都有一个Sleep 1s的操作。提出是否可以修改此代码
执行过程：
1.调研SDS-GO-SDK中Iter部分的源码，每次Iter过程中将实际的操作逻辑封装到协程中，在函数return之前通过sleep 1s的方式将CPU的时间片让给协程。查阅资料并未查到对于将“CPU时间片让给协程”这一过程的具体sleep时长是多少，但是一般常规的建议是调用runtime.Gosched()。

2.编写测试代码，发现sleep 1s的效率比不过runtime.Gosched()，在一个for loop中，构造自己的协程，发现如果通过sleep 1s的方式让出cput时间片给协程，效率比runtime.Goseched低很多，且协程运行结束后主线程在1s后才结束运行。因此将sleep 1s的代码替换为runtime.Gosched()