### PR TITLE
Remove time.Sleep from the tablescanner iter()

### DIFF
--- a/sds/client/tablescanner.go
+++ b/sds/client/tablescanner.go
@@ -64,6 +64,5 @@ func (p *TableScanner) Iter() <-chan *ScannedItem {
 		}
 		close(ch)
 	}()
-	time.Sleep(time.Second)
 	return ch
 }


### PR DESCRIPTION
背景：用户在使用SDS-GO-SDK时发现在使用scanner过程中每次调用Iter时延迟较大，查看源码后发现每次Iter结束后都有一个Sleep 1s的操作。提出是否可以修改此代码

用户原话：“ Iter 返回的是个 channel，如果 goroutine 里没有关闭 channel，会阻塞，所以不用手动调用 runtime.Gosched() ，协程没执行完成前不会继续往下，所以删除 sleep 就好了”

测试过程：在本项目的example里的basic.go中对scan过程前后进行时间打点，发现整个scan操作大于1s，去掉对应语句后，scan操作在500ms内完成。正如用户所述
