### PR TITLE
修改默认httpClient的配置，并增加替换方法以支持自定义httpClient

### DIFF
--- a/sds/client/clientfactory.go
+++ b/sds/client/clientfactory.go
@@ -29,7 +29,7 @@ func NewClientFactory(credential *auth.Credential, soTimeout time.Duration) Clie
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			Dial: func(network, addr string) (net.Conn, error) {
-				return net.DialTimeout(network, addr, soTimeout);
+				return net.DialTimeout(network, addr, soTimeout)
 			},
 		},
 	}

--- a/sds/client/clientfactory.go
+++ b/sds/client/clientfactory.go
@@ -29,11 +29,16 @@ func NewClientFactory(credential *auth.Credential, soTimeout time.Duration) Clie
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			Dial: func(network, addr string) (net.Conn, error) {
-				return net.DialTimeout(network, addr, soTimeout);
+				return net.DialTimeout(network, addr, soTimeout)
 			},
+			MaxIdleConnsPerHost: 10 * runtime.NumCPU(),
 		},
 	}
 	return ClientFactory{credential: credential, httpClient: httpClient, agent: agent}
+}
+
+func (cf *ClientFactory) SetHTTPClient(client *http.Client) {
+	cf.httpClient = client
 }
 
 func (cf *ClientFactory) NewDefaultAdminClient() (admin.AdminService) {

--- a/sds/client/clientfactory.go
+++ b/sds/client/clientfactory.go
@@ -31,7 +31,6 @@ func NewClientFactory(credential *auth.Credential, soTimeout time.Duration) Clie
 			Dial: func(network, addr string) (net.Conn, error) {
 				return net.DialTimeout(network, addr, soTimeout)
 			},
-			MaxIdleConnsPerHost: 10 * runtime.NumCPU(),
 		},
 	}
 	return ClientFactory{credential: credential, httpClient: httpClient, agent: agent}

--- a/sds/client/clientfactory.go
+++ b/sds/client/clientfactory.go
@@ -29,7 +29,7 @@ func NewClientFactory(credential *auth.Credential, soTimeout time.Duration) Clie
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			Dial: func(network, addr string) (net.Conn, error) {
-				return net.DialTimeout(network, addr, soTimeout)
+				return net.DialTimeout(network, addr, soTimeout);
 			},
 		},
 	}


### PR DESCRIPTION
MaxIdleConnsPerHost默认为2，当并发数大时，会造成频繁的创建和销毁链接
创建链接涉net.Dial、tls handshake等消耗CPU占比非常大
先将默认MaxIdleConnsPerHost调整为10 * runtime.NumCPU()，并提供根据自身业务需求去修改HTTPClient的方式